### PR TITLE
Handle absolute encoder wraparounds

### DIFF
--- a/src/main/java/com/team3181/frc2023/Constants.java
+++ b/src/main/java/com/team3181/frc2023/Constants.java
@@ -296,10 +296,10 @@ public final class Constants {
 
         // Set zero points to be the initial "stowed" position?
         // The Absolute offsets appear to be arbitrary?
-        public static final Rotation2d SHOULDER_ABSOLUTE_OFFSET = Rotation2d.fromRadians(1.5);
-        public static final Rotation2d SHOULDER_MATH_OFFSET = Rotation2d.fromRadians(-1.5366698503494263); // zero needs to be at shoulder parallel to ground
-        public static final Rotation2d ELBOW_ABSOLUTE_OFFSET = Rotation2d.fromRadians(1.5760794878005981);
-        public static final Rotation2d ELBOW_MATH_OFFSET = Rotation2d.fromRadians(-3.458858823776245); // zero is in line with shoulder
+        public static final Rotation2d SHOULDER_ABSOLUTE_OFFSET = Rotation2d.fromRadians(1.6980544328689575);
+        public static final Rotation2d SHOULDER_MATH_OFFSET = Rotation2d.fromRadians(-1.4508755207061768); // zero needs to be at shoulder parallel to ground
+        public static final Rotation2d ELBOW_ABSOLUTE_OFFSET = Rotation2d.fromRadians(0.42347046732902527);
+        public static final Rotation2d ELBOW_MATH_OFFSET = Rotation2d.fromRadians(-4.787408351898193); // zero is in line with shoulder
 
         public static final Rotation2d ELBOW_MIN = Rotation2d.fromDegrees(-140);
         public static final Rotation2d ELBOW_MAX = Rotation2d.fromDegrees(140);

--- a/src/main/java/com/team3181/frc2023/subsystems/fourbar/ArmIOElbowSparkMax.java
+++ b/src/main/java/com/team3181/frc2023/subsystems/fourbar/ArmIOElbowSparkMax.java
@@ -12,6 +12,9 @@ import edu.wpi.first.math.util.Units;
 public class ArmIOElbowSparkMax implements ArmIO {
     private final LazySparkMax motor;
     private final AbsoluteEncoder absoluteEncoder;
+    private double lastPos = FourBarConstants.ELBOW_MATH_OFFSET.getRadians();
+    private double wraparoundOffset = 0;
+    private double oneEncoderRotation = 2 * Math.PI;
 
     public ArmIOElbowSparkMax() {
         motor = new LazySparkMax(FourBarConstants.CAN_ELBOW, IdleMode.kBrake, 80, false,false);
@@ -28,11 +31,28 @@ public class ArmIOElbowSparkMax implements ArmIO {
 
     @Override
     public void updateInputs(ArmIOInputs inputs) {
-        inputs.armOffsetPositionRad = absoluteEncoder.getPosition() + FourBarConstants.ELBOW_MATH_OFFSET.getRadians();
+        double position = absoluteEncoder.getPosition() + FourBarConstants.ELBOW_MATH_OFFSET.getRadians() + wraparoundOffset;
+        double positionDiff = position - lastPos;
+
+        // Check if we've wrapped around the zero point.  If we've travelled more than a half circle in one update period,
+        // then assume we wrapped around.
+        if (positionDiff > oneEncoderRotation / 2) {
+            // We went up by over a half rotation, which means we likely wrapped around the zero point going in the negative direction.
+            position -= oneEncoderRotation;
+            wraparoundOffset -= oneEncoderRotation;
+        }
+        if (positionDiff < -1 * oneEncoderRotation / 2) {
+            // We went down by over a half rotation, which means we likely wrapped around the zero point going in the positive direction.
+            position += oneEncoderRotation;
+            wraparoundOffset += oneEncoderRotation;
+        }
+
+        inputs.armOffsetPositionRad = position;
         inputs.armVelocityRadPerSec = Units.rotationsPerMinuteToRadiansPerSecond(absoluteEncoder.getVelocity());
         inputs.armAppliedVolts = motor.getAppliedOutput() * motor.getBusVoltage();
         inputs.armCurrentAmps = motor.getOutputCurrent();
         inputs.armTempCelsius = motor.getMotorTemperature();
+        lastPos = position;
     }
 
     @Override

--- a/src/main/java/com/team3181/frc2023/subsystems/fourbar/ArmIOShoulderSparkMax.java
+++ b/src/main/java/com/team3181/frc2023/subsystems/fourbar/ArmIOShoulderSparkMax.java
@@ -15,7 +15,9 @@ public class ArmIOShoulderSparkMax implements ArmIO {
     private final LazySparkMax followerMotor;
     private final AbsoluteEncoder absoluteEncoder;
     private int counter = 0;
-    private double lastPos = 0;
+    private double lastPos = FourBarConstants.SHOULDER_MATH_OFFSET.getRadians();
+    private double wraparoundOffset = 0;
+    private double oneEncoderRotation = 2 * Math.PI * FourBarConstants.CHAIN_RATIO;
 
     public ArmIOShoulderSparkMax() {
         mainMotor = new LazySparkMax(FourBarConstants.CAN_SHOULDER_MASTER, IdleMode.kCoast, 80, true, false);
@@ -33,18 +35,35 @@ public class ArmIOShoulderSparkMax implements ArmIO {
 
     @Override
     public void updateInputs(ArmIOInputs inputs) {
-        if (lastPos < FourBarConstants.SHOULDER_FLIP_MIN.getRadians() + 0.1 && (absoluteEncoder.getPosition() + FourBarConstants.SHOULDER_MATH_OFFSET.getRadians()) > FourBarConstants.SHOULDER_FLIP_MAX.getRadians() - 0.1 && counter == 1) {
-            counter--;
-        } else if (lastPos > FourBarConstants.SHOULDER_FLIP_MAX.getRadians() - 0.1 && (absoluteEncoder.getPosition() + FourBarConstants.SHOULDER_MATH_OFFSET.getRadians()) < FourBarConstants.SHOULDER_FLIP_MIN.getRadians() + 0.1 && counter == 0) {
-            counter++;
-        }
+        double position = absoluteEncoder.getPosition() + FourBarConstants.SHOULDER_MATH_OFFSET.getRadians() + wraparoundOffset;
+        double positionDiff = position - lastPos;
 
-        inputs.armOffsetPositionRad = absoluteEncoder.getPosition() + FourBarConstants.SHOULDER_MATH_OFFSET.getRadians() + counter * (FourBarConstants.SHOULDER_FLIP_MIN.getRadians() * -1 + FourBarConstants.SHOULDER_FLIP_MAX.getRadians());
+        // Check if we've wrapped around the zero point.  If we've travelled more than a half circle in one update period,
+        // then assume we wrapped around.
+        if (positionDiff > oneEncoderRotation / 2) {
+            // We went up by over a half rotation, which means we likely wrapped around the zero point going in the negative direction.
+            position -= oneEncoderRotation;
+            wraparoundOffset -= oneEncoderRotation;
+        }
+        if (positionDiff < -1 * oneEncoderRotation / 2) {
+            // We went down by over a half rotation, which means we likely wrapped around the zero point going in the positive direction.
+            position += oneEncoderRotation;
+            wraparoundOffset += oneEncoderRotation;
+        }
+        
+        // if (lastPos < FourBarConstants.SHOULDER_FLIP_MIN.getRadians() + 0.1 && (position) > FourBarConstants.SHOULDER_FLIP_MAX.getRadians() - 0.1 && counter == 1) {
+        //     counter--;
+        // } else if (lastPos > FourBarConstants.SHOULDER_FLIP_MAX.getRadians() - 0.1 && (position) < FourBarConstants.SHOULDER_FLIP_MIN.getRadians() + 0.1 && counter == 0) {
+        //     counter++;
+        // }
+        //inputs.armOffsetPositionRad = position + counter * (FourBarConstants.SHOULDER_FLIP_MIN.getRadians() * -1 + FourBarConstants.SHOULDER_FLIP_MAX.getRadians());
+        
+        inputs.armOffsetPositionRad = position;
         inputs.armVelocityRadPerSec = Units.rotationsPerMinuteToRadiansPerSecond(absoluteEncoder.getVelocity());
-        lastPos = absoluteEncoder.getPosition() + FourBarConstants.SHOULDER_MATH_OFFSET.getRadians();
         inputs.armAppliedVolts = mainMotor.getAppliedOutput() * mainMotor.getBusVoltage();
         inputs.armCurrentAmps = mainMotor.getOutputCurrent();
         inputs.armTempCelsius = mainMotor.getMotorTemperature();
+        lastPos = position;
 
         Logger.getInstance().recordOutput("Shoulder/Counter", counter);
 


### PR DESCRIPTION
Implementing a more robust mechanism for handling situations where the shoulder or elbow absolute encoders hit their wraparound points.
I left the original code in place, but commented out, for easier comparison,.